### PR TITLE
Develop

### DIFF
--- a/nmeta2dpae/nmeta2dpae.py
+++ b/nmeta2dpae/nmeta2dpae.py
@@ -50,7 +50,7 @@ class DPAE(object):
         Initialise the DPAE class
         """
         #*** Version number for compatibility checks:
-        self.version = '0.3.3'
+        self.version = '0.3.4'
 
         #*** Instantiate config class which imports configuration file
         #*** config.yaml and provides access to keys/values:

--- a/nmeta2dpae/sniff.py
+++ b/nmeta2dpae/sniff.py
@@ -41,7 +41,9 @@ SIOCGIFFLAGS = 0x8913
 SIOCSIFFLAGS = 0x8914
 
 #*** MAC destinations to not forward:
-LLDP_NEAREST_BRIDGE = '01:80:c2:00:00:0e'
+MAC_LLDP_NEAREST_BRIDGE = '01:80:c2:00:00:0e'
+MAC_BROADCAST = 'ff:ff:ff:ff:ff:ff'
+DO_NOT_FORWARD_MACS = (MAC_LLDP_NEAREST_BRIDGE, MAC_BROADCAST)
 
 #*** TBD, this should be autodetected:
 MTU = 6000
@@ -151,7 +153,7 @@ class Sniff(object):
                 #*** Some types of packets shouldn't be forwarded:
                 #*** Read into dpkt (expensive?):
                 eth = dpkt.ethernet.Ethernet(pkt)
-                if mac_addr(eth.dst) == LLDP_NEAREST_BRIDGE:
+                if mac_addr(eth.dst) in DO_NOT_FORWARD_MACS:
                     continue
                 #*** Active Mode: send the packet back to the switch:
                 try:

--- a/nmeta2dpae/sniff.py
+++ b/nmeta2dpae/sniff.py
@@ -40,6 +40,9 @@ IFF_PROMISC = 0x100
 SIOCGIFFLAGS = 0x8913
 SIOCSIFFLAGS = 0x8914
 
+#*** MAC destinations to not forward:
+LLDP_NEAREST_BRIDGE = '01:80:c2:00:00:0e'
+
 #*** TBD, this should be autodetected:
 MTU = 6000
 
@@ -145,6 +148,14 @@ class Sniff(object):
                     queue.put(tc_result)
 
             if tc_mode == 'active':
+                #*** Some types of packets shouldn't be forwarded:
+                #*** Read into dpkt (expensive?):
+                eth = dpkt.ethernet.Ethernet(pkt)
+                if mac_addr(eth.dst) == LLDP_NEAREST_BRIDGE:
+                    # TEMP LOGGING:
+                    self.logger.info("NOT SENDING LLDP from %s to %s",
+                                                eth.src, eth.dst)
+                    continue
                 #*** Active Mode: send the packet back to the switch:
                 try:
                     mysock.send(pkt)

--- a/nmeta2dpae/sniff.py
+++ b/nmeta2dpae/sniff.py
@@ -152,9 +152,6 @@ class Sniff(object):
                 #*** Read into dpkt (expensive?):
                 eth = dpkt.ethernet.Ethernet(pkt)
                 if mac_addr(eth.dst) == LLDP_NEAREST_BRIDGE:
-                    # TEMP LOGGING:
-                    self.logger.info("NOT SENDING LLDP from %s to %s",
-                                                eth.src, eth.dst)
                     continue
                 #*** Active Mode: send the packet back to the switch:
                 try:


### PR DESCRIPTION
# Active Mode MAC Forwarding Filter

There are some types of packet that the DPAE should not reinject back to the switch. We now silently block the reinjection of packets destined for the broadcast or LLDP MAC addresses.
